### PR TITLE
Make createwrapper.t more robust to different types of path

### DIFF
--- a/API/src/createwrapper.t
+++ b/API/src/createwrapper.t
@@ -167,9 +167,10 @@ local terra NewState(params : Opt_InitializationParameters) : &LibraryState
 				command = "ls "
 			end 
 
-			print(command..sourcedirectory)
+			command = command..'"'..sourcedirectory..'"'
+			print(command)
 			
-            for line in io.popen(command..sourcedirectory):lines() do
+            for line in io.popen(command):lines() do
                 local name = line:match("(.*)%.t")
                 if name then
                     local content = io.open(sourcedirectory.."/"..line,"r"):read("*all")


### PR DESCRIPTION
## Intuition
I use a CMakeList.txt for Opt to handle the building step, which is more flexible to integrate the Opt project with my own project. However, the path in CMake **always** has forward slashes (even in Windows) so the command executed in `createwrapper.t` is like this: `cmd /c dir /d API/src`
It's known that Windows can handle the path with forward slashes but in this case, the path is not in quotes and the slash is seen as a parameter switch. It will generate an error like this:  
> Parameter format not correct - "src"

To avoid the error, I just put the path in quotes and I have verified that it works fine both for Linux and Windows.

## Main changes
 * Update API/src/createwrapper.t: put the path of directory in quotes, which makes the "dir" command more robust.