### PR TITLE
change param name to avoid CUDA solvers runtime error: "nonLinearIter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,7 @@ The functions are described in more details below.
     
 Create a new dimension used to describe the size of Arrays. `dimensions_position` is the 0-based offset into the `dimensions` argument to `Opt_ProblemPlan` that will be bound to this value. See 'Binding Values'.
 
-    local W =
-    H = Dim("W",0), Dim("H",1)
+    local W, H = Dim("W",0), Dim("H",1)
     
 ---
 

--- a/examples/image_warping/src/CUDAWarpingSolver.cpp
+++ b/examples/image_warping/src/CUDAWarpingSolver.cpp
@@ -65,8 +65,8 @@ double CUDAWarpingSolver::solve(const NamedParameters& solverParams, const Named
     SolverParameters parameters;
     parameters.weightFitting = sq(getTypedParameter<float>("w_fitSqrt", probParams));
     parameters.weightRegularizer = sq(getTypedParameter<float>("w_regSqrt", probParams));
-    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nonLinearIterations", solverParams);
-    parameters.nLinIterations = getTypedParameter<unsigned int>("linearIterations", solverParams);
+    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nIterations", solverParams);
+    parameters.nLinIterations = getTypedParameter<unsigned int>("lIterations", solverParams);
 	
 
     solverInput.N = m_dims[0] * m_dims[1];

--- a/examples/poisson_image_editing/poisson_image_editing.t
+++ b/examples/poisson_image_editing/poisson_image_editing.t
@@ -6,8 +6,10 @@ UsePreconditioner(false)
 
 -- do not include unmasked pixels in the solve
 Exclude(Not(eq(M(0,0),0)))
+--Exclude(eq(M(0,0),0))
 
+w_t = 1.5	--weighting test
 for x,y in Stencil { {1,0},{-1,0},{0,1},{0,-1} } do
-    local e = (X(0,0) - X(x,y)) - (T(0,0) - T(x,y))
+    local e = (X(0,0) - X(x,y)) - w_t * (T(0,0) - T(x,y))
     Energy(Select(InBounds(x,y),e,0))
 end

--- a/examples/poisson_image_editing/src/CUDAPatchSolverWarping.cpp
+++ b/examples/poisson_image_editing/src/CUDAPatchSolverWarping.cpp
@@ -23,8 +23,8 @@ double CUDAPatchSolverWarping::solve(const NamedParameters& solverParams, const 
     m_solverState.d_x = getTypedParameterImage<float4>("X", probParams);
 
     PatchSolverParameters parameters;
-    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nonLinearIterations", solverParams);
-    parameters.nLinearIterations    = getTypedParameter<unsigned int>("linearIterations", solverParams);
+    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nIterations", solverParams);
+    parameters.nLinearIterations    = getTypedParameter<unsigned int>("lIterations", solverParams);
     parameters.nPatchIterations     = patchIter;
 
 	PatchSolverInput solverInput;

--- a/examples/poisson_image_editing/src/CUDAWarpingSolver.cpp
+++ b/examples/poisson_image_editing/src/CUDAWarpingSolver.cpp
@@ -45,8 +45,8 @@ double CUDAWarpingSolver::solve(const NamedParameters& solverParams, const Named
     m_solverState.d_x       = getTypedParameterImage<float4>("X", probParams);
 
 	SolverParameters parameters;
-    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nonLinearIterations", solverParams);
-    parameters.nLinIterations = getTypedParameter<unsigned int>("linearIterations", solverParams);
+    parameters.nNonLinearIterations = getTypedParameter<unsigned int>("nIterations", solverParams);
+    parameters.nLinIterations = getTypedParameter<unsigned int>("lIterations", solverParams);
 	
 	SolverInput solverInput;
     solverInput.N = m_dims[0] * m_dims[1];

--- a/examples/shape_from_shading/src/CUDAImageSolver.cpp
+++ b/examples/shape_from_shading/src/CUDAImageSolver.cpp
@@ -90,8 +90,8 @@ double CUDAImageSolver::solve(const NamedParameters& solverParams, const NamedPa
     parameters.weightRegularizer        = getTypedParameter<float>("w_s", probParams); //rawSolverInput.parameters.weightRegularizer;
     parameters.weightBoundary           = 0.0f; //unused rawSolverInput.parameters.weightBoundary;
     parameters.weightPrior              = 0.0f;//unused rawSolverInput.parameters.weightPrior;
-    parameters.nNonLinearIterations     = getTypedParameter<unsigned int>("nonLinearIterations", solverParams);
-    parameters.nLinIterations           = getTypedParameter<unsigned int>("linearIterations", solverParams);
+    parameters.nNonLinearIterations     = getTypedParameter<unsigned int>("nIterations", solverParams);
+    parameters.nLinIterations           = getTypedParameter<unsigned int>("lIterations", solverParams);
     parameters.nPatchIterations         = 1; //unused rawSolverInput.parameters.nPatchIterations;
 	
     ConvergenceAnalysis<float>* ca = NULL;

--- a/examples/shape_from_shading/src/SimpleBuffer.cpp
+++ b/examples/shape_from_shading/src/SimpleBuffer.cpp
@@ -30,13 +30,14 @@ SimpleBuffer::SimpleBuffer(std::string filename, bool onGPU, bool clampInfinity)
     if (m_dataType == 0 && clampInfinity) {
       float* fPtr = (float*)ptr;
       for (int i = 0; i < m_width*m_height; ++i) {
-	if (std::isinf(fPtr[i])) {
-	  if (fPtr[i] > 0) {
-	    fPtr[i] = std::numeric_limits<float>::max();
-	  } else {
-	    fPtr[i] = -10000.0f;
-	  }
-	}
+          if (std::isinf(fPtr[i])) {
+              if (fPtr[i] > 0) {
+                  fPtr[i] = std::numeric_limits<float>::max();
+              }
+              else {
+                  fPtr[i] = -10000.0f;
+              }
+          }
       }
     }
 

--- a/tests/minimal/laplacian.t
+++ b/tests/minimal/laplacian.t
@@ -2,6 +2,10 @@ W,H = Dim("W",0), Dim("H",1)
 X = Unknown("X",float,{W,H},0)
 A = Array("A",float,{W,H},1)
 w_fit = .2
-Energy(w_fit*(X(0,0) - A(0,0)), --fitting
-(X(0,0) - X(1,0)), --regularization
-(X(0,0) - X(0,1)))
+nbr_step = 3
+Energy(w_fit*(X(0,0) - A(0,0)) --fitting
+,(X(0,0) - X(nbr_step,0)) --regularization
+,(X(0,0) - X(0,nbr_step))
+,(X(0,0) - X(-nbr_step,0))
+,(X(0,0) - X(0,-nbr_step))
+)


### PR DESCRIPTION
…ations" -> "nIterations", "linearIterations" -> "lIterations"

since this commit: https://github.com/niessner/Opt/commit/f96f62640fc0c353414e25752d356fb6d440c7ad#diff-4ec1b09480d2efd4ac57e2db04ec1bdd

the param names have been changed in `examples/shape_from_shading/src/CombinedSolver.h`